### PR TITLE
Refine DTO responses with inventory-facing details

### DIFF
--- a/src/main/java/com/inventa/inventa/dto/ajusteinventario/AjusteInventarioRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/ajusteinventario/AjusteInventarioRequestDTO.java
@@ -1,0 +1,16 @@
+package com.inventa.inventa.dto.ajusteinventario;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class AjusteInventarioRequestDTO {
+    private Integer loteId;
+    private Integer usuarioId;
+    private LocalDateTime fechaAjuste;
+    private String tipoAjuste;
+    private BigDecimal cantidad;
+    private String motivo;
+}

--- a/src/main/java/com/inventa/inventa/dto/ajusteinventario/AjusteInventarioResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/ajusteinventario/AjusteInventarioResponseDTO.java
@@ -1,0 +1,20 @@
+package com.inventa.inventa.dto.ajusteinventario;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class AjusteInventarioResponseDTO {
+    private Integer ajusteId;
+    private Integer loteId;
+    private Integer productoId;
+    private String productoNombre;
+    private Integer usuarioId;
+    private String usuarioNombre;
+    private LocalDateTime fechaAjuste;
+    private String tipoAjuste;
+    private BigDecimal cantidad;
+    private String motivo;
+}

--- a/src/main/java/com/inventa/inventa/dto/cliente/ClienteRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/cliente/ClienteRequestDTO.java
@@ -1,0 +1,12 @@
+package com.inventa.inventa.dto.cliente;
+
+import lombok.Data;
+
+@Data
+public class ClienteRequestDTO {
+    private String nombreCompleto;
+    private String identificacionFiscal;
+    private String telefono;
+    private String direccion;
+    private String tipoCliente;
+}

--- a/src/main/java/com/inventa/inventa/dto/cliente/ClienteResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/cliente/ClienteResponseDTO.java
@@ -1,0 +1,13 @@
+package com.inventa.inventa.dto.cliente;
+
+import lombok.Data;
+
+@Data
+public class ClienteResponseDTO {
+    private Integer clienteId;
+    private String nombreCompleto;
+    private String identificacionFiscal;
+    private String telefono;
+    private String direccion;
+    private String tipoCliente;
+}

--- a/src/main/java/com/inventa/inventa/dto/compra/CompraRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/compra/CompraRequestDTO.java
@@ -1,0 +1,15 @@
+package com.inventa.inventa.dto.compra;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class CompraRequestDTO {
+    private Integer proveedorId;
+    private Integer usuarioId;
+    private LocalDate fechaCompra;
+    private String numeroFactura;
+    private BigDecimal montoTotal;
+}

--- a/src/main/java/com/inventa/inventa/dto/compra/CompraResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/compra/CompraResponseDTO.java
@@ -1,0 +1,18 @@
+package com.inventa.inventa.dto.compra;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class CompraResponseDTO {
+    private Integer compraId;
+    private Integer proveedorId;
+    private String proveedorNombre;
+    private Integer usuarioId;
+    private String usuarioNombre;
+    private LocalDate fechaCompra;
+    private String numeroFactura;
+    private BigDecimal montoTotal;
+}

--- a/src/main/java/com/inventa/inventa/dto/contactoproveedor/ContactoProveedorRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/contactoproveedor/ContactoProveedorRequestDTO.java
@@ -1,0 +1,12 @@
+package com.inventa.inventa.dto.contactoproveedor;
+
+import lombok.Data;
+
+@Data
+public class ContactoProveedorRequestDTO {
+    private Integer proveedorId;
+    private String nombreCompleto;
+    private String cargo;
+    private String telefono;
+    private String email;
+}

--- a/src/main/java/com/inventa/inventa/dto/contactoproveedor/ContactoProveedorResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/contactoproveedor/ContactoProveedorResponseDTO.java
@@ -1,0 +1,14 @@
+package com.inventa.inventa.dto.contactoproveedor;
+
+import lombok.Data;
+
+@Data
+public class ContactoProveedorResponseDTO {
+    private Integer contactoId;
+    private Integer proveedorId;
+    private String proveedorNombre;
+    private String nombreCompleto;
+    private String cargo;
+    private String telefono;
+    private String email;
+}

--- a/src/main/java/com/inventa/inventa/dto/detallecompra/DetalleCompraRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/detallecompra/DetalleCompraRequestDTO.java
@@ -1,0 +1,14 @@
+package com.inventa.inventa.dto.detallecompra;
+
+import java.math.BigDecimal;
+
+import lombok.Data;
+
+@Data
+public class DetalleCompraRequestDTO {
+    private Integer compraId;
+    private Integer productoId;
+    private BigDecimal cantidad;
+    private BigDecimal costoUnitarioCompra;
+    private BigDecimal subtotal;
+}

--- a/src/main/java/com/inventa/inventa/dto/detallecompra/DetalleCompraResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/detallecompra/DetalleCompraResponseDTO.java
@@ -1,0 +1,16 @@
+package com.inventa.inventa.dto.detallecompra;
+
+import java.math.BigDecimal;
+
+import lombok.Data;
+
+@Data
+public class DetalleCompraResponseDTO {
+    private Integer detalleCompraId;
+    private Integer compraId;
+    private Integer productoId;
+    private String productoNombre;
+    private BigDecimal cantidad;
+    private BigDecimal costoUnitarioCompra;
+    private BigDecimal subtotal;
+}

--- a/src/main/java/com/inventa/inventa/dto/detalleventa/DetalleVentaRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/detalleventa/DetalleVentaRequestDTO.java
@@ -1,0 +1,14 @@
+package com.inventa.inventa.dto.detalleventa;
+
+import java.math.BigDecimal;
+
+import lombok.Data;
+
+@Data
+public class DetalleVentaRequestDTO {
+    private Integer ventaId;
+    private Integer loteId;
+    private BigDecimal cantidad;
+    private BigDecimal precioUnitarioVenta;
+    private BigDecimal subtotal;
+}

--- a/src/main/java/com/inventa/inventa/dto/detalleventa/DetalleVentaResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/detalleventa/DetalleVentaResponseDTO.java
@@ -1,0 +1,17 @@
+package com.inventa.inventa.dto.detalleventa;
+
+import java.math.BigDecimal;
+
+import lombok.Data;
+
+@Data
+public class DetalleVentaResponseDTO {
+    private Integer detalleId;
+    private Integer ventaId;
+    private Integer loteId;
+    private Integer productoId;
+    private String productoNombre;
+    private BigDecimal cantidad;
+    private BigDecimal precioUnitarioVenta;
+    private BigDecimal subtotal;
+}

--- a/src/main/java/com/inventa/inventa/dto/lote/LoteRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/lote/LoteRequestDTO.java
@@ -1,0 +1,15 @@
+package com.inventa.inventa.dto.lote;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class LoteRequestDTO {
+    private Integer productoId;
+    private Integer detalleCompraId;
+    private LocalDate fechaCaducidad;
+    private BigDecimal cantidadInicial;
+    private BigDecimal cantidadActual;
+}

--- a/src/main/java/com/inventa/inventa/dto/lote/LoteResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/lote/LoteResponseDTO.java
@@ -1,0 +1,18 @@
+package com.inventa.inventa.dto.lote;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class LoteResponseDTO {
+    private Integer loteId;
+    private Integer productoId;
+    private String productoNombre;
+    private String skuProducto;
+    private Integer detalleCompraId;
+    private LocalDate fechaCaducidad;
+    private BigDecimal cantidadInicial;
+    private BigDecimal cantidadActual;
+}

--- a/src/main/java/com/inventa/inventa/dto/producto/ProductoRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/producto/ProductoRequestDTO.java
@@ -1,0 +1,19 @@
+package com.inventa.inventa.dto.producto;
+
+import java.math.BigDecimal;
+
+import lombok.Data;
+
+@Data
+public class ProductoRequestDTO {
+    private String sku;
+    private String nombre;
+    private String descripcion;
+    private BigDecimal ultimoCosto;
+    private BigDecimal precioMinorista;
+    private BigDecimal precioMayorista;
+    private BigDecimal stockActual;
+    private BigDecimal stockMinimo;
+    private String unidadMedida;
+    private Integer categoriaId;
+}

--- a/src/main/java/com/inventa/inventa/dto/producto/ProductoResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/producto/ProductoResponseDTO.java
@@ -1,0 +1,21 @@
+package com.inventa.inventa.dto.producto;
+
+import java.math.BigDecimal;
+
+import lombok.Data;
+
+@Data
+public class ProductoResponseDTO {
+    private Integer productoId;
+    private String sku;
+    private String nombre;
+    private String descripcion;
+    private BigDecimal ultimoCosto;
+    private BigDecimal precioMinorista;
+    private BigDecimal precioMayorista;
+    private BigDecimal stockActual;
+    private BigDecimal stockMinimo;
+    private String unidadMedida;
+    private Integer categoriaId;
+    private String categoriaNombre;
+}

--- a/src/main/java/com/inventa/inventa/dto/proveedor/ProveedorRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/proveedor/ProveedorRequestDTO.java
@@ -1,0 +1,10 @@
+package com.inventa.inventa.dto.proveedor;
+
+import lombok.Data;
+
+@Data
+public class ProveedorRequestDTO {
+    private String nombreEmpresa;
+    private String telefono;
+    private String direccion;
+}

--- a/src/main/java/com/inventa/inventa/dto/proveedor/ProveedorResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/proveedor/ProveedorResponseDTO.java
@@ -1,0 +1,11 @@
+package com.inventa.inventa.dto.proveedor;
+
+import lombok.Data;
+
+@Data
+public class ProveedorResponseDTO {
+    private Integer proveedorId;
+    private String nombreEmpresa;
+    private String telefono;
+    private String direccion;
+}

--- a/src/main/java/com/inventa/inventa/dto/rol/RolRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/rol/RolRequestDTO.java
@@ -1,0 +1,8 @@
+package com.inventa.inventa.dto.rol;
+
+import lombok.Data;
+
+@Data
+public class RolRequestDTO {
+    private String nombreRol;
+}

--- a/src/main/java/com/inventa/inventa/dto/rol/RolResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/rol/RolResponseDTO.java
@@ -1,0 +1,9 @@
+package com.inventa.inventa.dto.rol;
+
+import lombok.Data;
+
+@Data
+public class RolResponseDTO {
+    private Integer rolId;
+    private String nombreRol;
+}

--- a/src/main/java/com/inventa/inventa/dto/tokenrecuperacion/TokenRecuperacionRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/tokenrecuperacion/TokenRecuperacionRequestDTO.java
@@ -1,0 +1,13 @@
+package com.inventa.inventa.dto.tokenrecuperacion;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class TokenRecuperacionRequestDTO {
+    private Integer usuarioId;
+    private String token;
+    private LocalDateTime fechaExpiracion;
+    private Boolean usado;
+}

--- a/src/main/java/com/inventa/inventa/dto/tokenrecuperacion/TokenRecuperacionResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/tokenrecuperacion/TokenRecuperacionResponseDTO.java
@@ -1,0 +1,15 @@
+package com.inventa.inventa.dto.tokenrecuperacion;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class TokenRecuperacionResponseDTO {
+    private Integer tokenId;
+    private Integer usuarioId;
+    private String nombreUsuario;
+    private String token;
+    private LocalDateTime fechaExpiracion;
+    private Boolean usado;
+}

--- a/src/main/java/com/inventa/inventa/dto/usuario/UsuarioRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/usuario/UsuarioRequestDTO.java
@@ -1,0 +1,14 @@
+package com.inventa.inventa.dto.usuario;
+
+import lombok.Data;
+
+@Data
+public class UsuarioRequestDTO {
+    private String nombreCompleto;
+    private String cuiDpi;
+    private String nombreUsuario;
+    private String contrasena;
+    private Integer rolId;
+    private String correo;
+    private String telefono;
+}

--- a/src/main/java/com/inventa/inventa/dto/usuario/UsuarioResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/usuario/UsuarioResponseDTO.java
@@ -1,0 +1,18 @@
+package com.inventa.inventa.dto.usuario;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class UsuarioResponseDTO {
+    private Integer usuarioId;
+    private String nombreCompleto;
+    private String cuiDpi;
+    private String nombreUsuario;
+    private Integer rolId;
+    private String nombreRol;
+    private LocalDateTime fechaCreacion;
+    private String correo;
+    private String telefono;
+}

--- a/src/main/java/com/inventa/inventa/dto/venta/VentaRequestDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/venta/VentaRequestDTO.java
@@ -1,0 +1,15 @@
+package com.inventa.inventa.dto.venta;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class VentaRequestDTO {
+    private Integer usuarioId;
+    private Integer clienteId;
+    private LocalDateTime fechaVenta;
+    private BigDecimal montoTotal;
+    private String metodoPago;
+}

--- a/src/main/java/com/inventa/inventa/dto/venta/VentaResponseDTO.java
+++ b/src/main/java/com/inventa/inventa/dto/venta/VentaResponseDTO.java
@@ -1,0 +1,18 @@
+package com.inventa.inventa.dto.venta;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Data;
+
+@Data
+public class VentaResponseDTO {
+    private Integer ventaId;
+    private Integer usuarioId;
+    private String usuarioNombre;
+    private Integer clienteId;
+    private String clienteNombre;
+    private LocalDateTime fechaVenta;
+    private BigDecimal montoTotal;
+    private String metodoPago;
+}


### PR DESCRIPTION
## Summary
- include related entity display fields in response DTOs for purchases, sales, lots, and inventory adjustments
- remove password exposure from UsuarioResponseDTO and drop fechaCreacion from the request payload
- align lot, token, and contact responses with descriptive fields useful for POS and inventory views

## Testing
- `./gradlew test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68d956094c848328986a3329fa46285c