### PR TITLE
Add inventory adjustments and provider contact API endpoints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/inventa/inventa/controller/AjusteInventarioController.java
+++ b/src/main/java/com/inventa/inventa/controller/AjusteInventarioController.java
@@ -1,0 +1,76 @@
+package com.inventa.inventa.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.inventa.inventa.dto.ajusteinventario.AjusteInventarioRequestDTO;
+import com.inventa.inventa.dto.ajusteinventario.AjusteInventarioResponseDTO;
+import com.inventa.inventa.entity.AjusteInventario;
+import com.inventa.inventa.mapper.AjusteInventarioMapper;
+import com.inventa.inventa.service.AjusteInventarioService;
+
+@RestController
+@RequestMapping("/api/ajustes-inventario")
+public class AjusteInventarioController {
+
+    private final AjusteInventarioService ajusteInventarioService;
+    private final AjusteInventarioMapper ajusteInventarioMapper;
+
+    public AjusteInventarioController(AjusteInventarioService ajusteInventarioService,
+            AjusteInventarioMapper ajusteInventarioMapper) {
+        this.ajusteInventarioService = ajusteInventarioService;
+        this.ajusteInventarioMapper = ajusteInventarioMapper;
+    }
+
+    @GetMapping
+    public List<AjusteInventarioResponseDTO> listar() {
+        return ajusteInventarioService.listar().stream().map(ajusteInventarioMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/{id}")
+    public AjusteInventarioResponseDTO obtenerPorId(@PathVariable Integer id) {
+        AjusteInventario ajuste = ajusteInventarioService.buscarPorId(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ajuste no encontrado"));
+        return ajusteInventarioMapper.toResponse(ajuste);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public AjusteInventarioResponseDTO crear(@RequestBody AjusteInventarioRequestDTO dto) {
+        AjusteInventario ajuste = new AjusteInventario();
+        ajusteInventarioMapper.updateEntityFromRequest(ajuste, dto);
+        AjusteInventario guardado = ajusteInventarioService.guardar(ajuste);
+        return ajusteInventarioMapper.toResponse(guardado);
+    }
+
+    @PutMapping("/{id}")
+    public AjusteInventarioResponseDTO actualizar(@PathVariable Integer id,
+            @RequestBody AjusteInventarioRequestDTO dto) {
+        AjusteInventario ajusteActualizado = new AjusteInventario();
+        ajusteInventarioMapper.updateEntityFromRequest(ajusteActualizado, dto);
+        AjusteInventario actualizado = ajusteInventarioService.actualizar(id, ajusteActualizado);
+        return ajusteInventarioMapper.toResponse(actualizado);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void eliminar(@PathVariable Integer id) {
+        if (ajusteInventarioService.buscarPorId(id).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Ajuste no encontrado");
+        }
+        ajusteInventarioService.eliminar(id);
+    }
+}

--- a/src/main/java/com/inventa/inventa/controller/ContactoProveedorController.java
+++ b/src/main/java/com/inventa/inventa/controller/ContactoProveedorController.java
@@ -1,0 +1,81 @@
+package com.inventa.inventa.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.inventa.inventa.dto.contactoproveedor.ContactoProveedorRequestDTO;
+import com.inventa.inventa.dto.contactoproveedor.ContactoProveedorResponseDTO;
+import com.inventa.inventa.entity.ContactoProveedor;
+import com.inventa.inventa.mapper.ContactoProveedorMapper;
+import com.inventa.inventa.service.ContactoProveedorService;
+
+@RestController
+@RequestMapping("/api/contactos-proveedor")
+public class ContactoProveedorController {
+
+    private final ContactoProveedorService contactoProveedorService;
+    private final ContactoProveedorMapper contactoProveedorMapper;
+
+    public ContactoProveedorController(ContactoProveedorService contactoProveedorService,
+            ContactoProveedorMapper contactoProveedorMapper) {
+        this.contactoProveedorService = contactoProveedorService;
+        this.contactoProveedorMapper = contactoProveedorMapper;
+    }
+
+    @GetMapping
+    public List<ContactoProveedorResponseDTO> listar() {
+        return contactoProveedorService.listar().stream().map(contactoProveedorMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/{id}")
+    public ContactoProveedorResponseDTO obtenerPorId(@PathVariable Integer id) {
+        ContactoProveedor contacto = contactoProveedorService.buscarPorId(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Contacto no encontrado"));
+        return contactoProveedorMapper.toResponse(contacto);
+    }
+
+    @GetMapping("/proveedor/{proveedorId}")
+    public List<ContactoProveedorResponseDTO> listarPorProveedor(@PathVariable Integer proveedorId) {
+        return contactoProveedorService.listarPorProveedor(proveedorId).stream()
+                .map(contactoProveedorMapper::toResponse).collect(Collectors.toList());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ContactoProveedorResponseDTO crear(@RequestBody ContactoProveedorRequestDTO dto) {
+        ContactoProveedor contacto = new ContactoProveedor();
+        contactoProveedorMapper.updateEntityFromRequest(contacto, dto);
+        return contactoProveedorMapper.toResponse(contactoProveedorService.guardar(contacto));
+    }
+
+    @PutMapping("/{id}")
+    public ContactoProveedorResponseDTO actualizar(@PathVariable Integer id,
+            @RequestBody ContactoProveedorRequestDTO dto) {
+        ContactoProveedor contacto = contactoProveedorService.buscarPorId(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Contacto no encontrado"));
+        contactoProveedorMapper.updateEntityFromRequest(contacto, dto);
+        return contactoProveedorMapper.toResponse(contactoProveedorService.guardar(contacto));
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void eliminar(@PathVariable Integer id) {
+        if (contactoProveedorService.buscarPorId(id).isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Contacto no encontrado");
+        }
+        contactoProveedorService.eliminar(id);
+    }
+}

--- a/src/main/java/com/inventa/inventa/mapper/AjusteInventarioMapper.java
+++ b/src/main/java/com/inventa/inventa/mapper/AjusteInventarioMapper.java
@@ -1,0 +1,96 @@
+package com.inventa.inventa.mapper;
+
+import java.util.Locale;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.inventa.inventa.dto.ajusteinventario.AjusteInventarioRequestDTO;
+import com.inventa.inventa.dto.ajusteinventario.AjusteInventarioResponseDTO;
+import com.inventa.inventa.entity.AjusteInventario;
+import com.inventa.inventa.entity.AjusteInventario.TipoAjuste;
+import com.inventa.inventa.entity.Lote;
+import com.inventa.inventa.entity.Usuario;
+import com.inventa.inventa.service.LoteService;
+import com.inventa.inventa.service.UsuarioService;
+
+@Component
+public class AjusteInventarioMapper {
+
+    private final LoteService loteService;
+    private final UsuarioService usuarioService;
+
+    public AjusteInventarioMapper(LoteService loteService, UsuarioService usuarioService) {
+        this.loteService = loteService;
+        this.usuarioService = usuarioService;
+    }
+
+    public void updateEntityFromRequest(AjusteInventario ajuste, AjusteInventarioRequestDTO dto) {
+        if (dto.getLoteId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El identificador del lote es obligatorio");
+        }
+        if (dto.getUsuarioId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El identificador del usuario es obligatorio");
+        }
+        Lote lote = loteService.buscarPorId(dto.getLoteId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lote no encontrado"));
+        Usuario usuario = usuarioService.buscarPorId(dto.getUsuarioId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Usuario no encontrado"));
+
+        ajuste.setLote(lote);
+        ajuste.setUsuario(usuario);
+        ajuste.setTipoAjuste(parseTipoAjuste(dto.getTipoAjuste()));
+        ajuste.setCantidad(dto.getCantidad());
+        ajuste.setMotivo(dto.getMotivo());
+    }
+
+    public AjusteInventarioResponseDTO toResponse(AjusteInventario ajuste) {
+        AjusteInventarioResponseDTO dto = new AjusteInventarioResponseDTO();
+        dto.setAjusteId(ajuste.getAjusteId());
+        if (ajuste.getLote() != null) {
+            dto.setLoteId(ajuste.getLote().getLoteId());
+            if (ajuste.getLote().getProducto() != null) {
+                dto.setProductoId(ajuste.getLote().getProducto().getProductoId());
+                dto.setProductoNombre(ajuste.getLote().getProducto().getNombre());
+            }
+        }
+        if (ajuste.getUsuario() != null) {
+            dto.setUsuarioId(ajuste.getUsuario().getUsuarioId());
+            dto.setUsuarioNombre(ajuste.getUsuario().getNombreCompleto());
+        }
+        dto.setFechaAjuste(ajuste.getFechaAjuste());
+        if (ajuste.getTipoAjuste() != null) {
+            dto.setTipoAjuste(ajuste.getTipoAjuste().name());
+        }
+        dto.setCantidad(ajuste.getCantidad());
+        dto.setMotivo(ajuste.getMotivo());
+        return dto;
+    }
+
+    private TipoAjuste parseTipoAjuste(String tipo) {
+        if (tipo == null || tipo.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El tipo de ajuste es obligatorio");
+        }
+        String normalizado = tipo.trim().toUpperCase(Locale.ROOT);
+        try {
+            if ("ENTRADA".equals(normalizado)) {
+                return TipoAjuste.Entrada;
+            }
+            if ("SALIDA".equals(normalizado)) {
+                return TipoAjuste.Salida;
+            }
+            return TipoAjuste.valueOf(capitalize(normalizado));
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Tipo de ajuste inválido");
+        }
+    }
+
+    private String capitalize(String value) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        String lower = value.toLowerCase(Locale.ROOT);
+        return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+    }
+}

--- a/src/main/java/com/inventa/inventa/mapper/ContactoProveedorMapper.java
+++ b/src/main/java/com/inventa/inventa/mapper/ContactoProveedorMapper.java
@@ -1,0 +1,49 @@
+package com.inventa.inventa.mapper;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.inventa.inventa.dto.contactoproveedor.ContactoProveedorRequestDTO;
+import com.inventa.inventa.dto.contactoproveedor.ContactoProveedorResponseDTO;
+import com.inventa.inventa.entity.ContactoProveedor;
+import com.inventa.inventa.entity.Proveedor;
+import com.inventa.inventa.service.ProveedorService;
+
+@Component
+public class ContactoProveedorMapper {
+
+    private final ProveedorService proveedorService;
+
+    public ContactoProveedorMapper(ProveedorService proveedorService) {
+        this.proveedorService = proveedorService;
+    }
+
+    public void updateEntityFromRequest(ContactoProveedor contacto, ContactoProveedorRequestDTO dto) {
+        if (dto.getProveedorId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El proveedor es obligatorio");
+        }
+        Proveedor proveedor = proveedorService.buscarPorId(dto.getProveedorId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Proveedor no encontrado"));
+
+        contacto.setProveedor(proveedor);
+        contacto.setNombreCompleto(dto.getNombreCompleto());
+        contacto.setCargo(dto.getCargo());
+        contacto.setTelefono(dto.getTelefono());
+        contacto.setEmail(dto.getEmail());
+    }
+
+    public ContactoProveedorResponseDTO toResponse(ContactoProveedor contacto) {
+        ContactoProveedorResponseDTO dto = new ContactoProveedorResponseDTO();
+        dto.setContactoId(contacto.getContactoId());
+        if (contacto.getProveedor() != null) {
+            dto.setProveedorId(contacto.getProveedor().getProveedorId());
+            dto.setProveedorNombre(contacto.getProveedor().getNombreEmpresa());
+        }
+        dto.setNombreCompleto(contacto.getNombreCompleto());
+        dto.setCargo(contacto.getCargo());
+        dto.setTelefono(contacto.getTelefono());
+        dto.setEmail(contacto.getEmail());
+        return dto;
+    }
+}

--- a/src/main/java/com/inventa/inventa/repository/ContactoProveedorRepository.java
+++ b/src/main/java/com/inventa/inventa/repository/ContactoProveedorRepository.java
@@ -3,8 +3,11 @@ package com.inventa.inventa.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 import com.inventa.inventa.entity.ContactoProveedor;
 
 @Repository
 public interface ContactoProveedorRepository extends JpaRepository<ContactoProveedor, Integer> {
+    List<ContactoProveedor> findByProveedorProveedorId(Integer proveedorId);
 }

--- a/src/main/java/com/inventa/inventa/service/AjusteInventarioService.java
+++ b/src/main/java/com/inventa/inventa/service/AjusteInventarioService.java
@@ -1,18 +1,32 @@
 package com.inventa.inventa.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.inventa.inventa.entity.AjusteInventario;
+import com.inventa.inventa.entity.AjusteInventario.TipoAjuste;
+import com.inventa.inventa.entity.Lote;
+import com.inventa.inventa.entity.Producto;
 import com.inventa.inventa.repository.AjusteInventarioRepository;
+
 
 @Service
 public class AjusteInventarioService {
     private final AjusteInventarioRepository ajusteInventarioRepository;
+    private final LoteService loteService;
+    private final ProductoService productoService;
 
-    public AjusteInventarioService(AjusteInventarioRepository ajusteInventarioRepository) {
+    public AjusteInventarioService(AjusteInventarioRepository ajusteInventarioRepository, LoteService loteService,
+            ProductoService productoService) {
         this.ajusteInventarioRepository = ajusteInventarioRepository;
+        this.loteService = loteService;
+        this.productoService = productoService;
     }
 
     public List<AjusteInventario> listar() {
@@ -23,11 +37,119 @@ public class AjusteInventarioService {
         return ajusteInventarioRepository.findById(id);
     }
 
+    @Transactional
     public AjusteInventario guardar(AjusteInventario ajuste) {
+        validarCantidad(ajuste.getCantidad());
+
+        Lote lote = obtenerLoteGestionado(ajuste.getLote());
+        ajuste.setLote(lote);
+
+        aplicarAjusteSobreInventario(lote, ajuste.getTipoAjuste(), ajuste.getCantidad());
+
+        productoService.guardar(lote.getProducto());
+        loteService.guardar(lote);
+
         return ajusteInventarioRepository.save(ajuste);
     }
 
+    @Transactional
+    public AjusteInventario actualizar(Integer id, AjusteInventario ajusteActualizado) {
+        validarCantidad(ajusteActualizado.getCantidad());
+
+        AjusteInventario existente = ajusteInventarioRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ajuste no encontrado"));
+
+        revertirImpactoInventario(existente);
+
+        Lote loteNuevo = obtenerLoteGestionado(ajusteActualizado.getLote());
+
+        existente.setLote(loteNuevo);
+        existente.setUsuario(ajusteActualizado.getUsuario());
+        existente.setTipoAjuste(ajusteActualizado.getTipoAjuste());
+        existente.setCantidad(ajusteActualizado.getCantidad());
+        existente.setMotivo(ajusteActualizado.getMotivo());
+
+        aplicarAjusteSobreInventario(loteNuevo, existente.getTipoAjuste(), existente.getCantidad());
+
+        productoService.guardar(loteNuevo.getProducto());
+        loteService.guardar(loteNuevo);
+
+        return ajusteInventarioRepository.save(existente);
+    }
+
+    @Transactional
     public void eliminar(Integer id) {
-        ajusteInventarioRepository.deleteById(id);
+        AjusteInventario ajuste = ajusteInventarioRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Ajuste no encontrado"));
+
+        revertirImpactoInventario(ajuste);
+
+        ajusteInventarioRepository.delete(ajuste);
+    }
+
+    private void validarCantidad(BigDecimal cantidad) {
+        if (cantidad == null || cantidad.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "La cantidad debe ser mayor a cero");
+        }
+    }
+
+    private Lote obtenerLoteGestionado(Lote lote) {
+        if (lote == null || lote.getLoteId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Lote inválido para el ajuste");
+        }
+        return loteService.buscarPorId(lote.getLoteId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Lote no encontrado"));
+    }
+
+    private void aplicarAjusteSobreInventario(Lote lote, TipoAjuste tipoAjuste, BigDecimal cantidad) {
+        if (tipoAjuste == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "El tipo de ajuste es obligatorio");
+        }
+        Producto producto = lote.getProducto();
+        if (producto == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "El lote seleccionado no tiene un producto asociado");
+        }
+
+        BigDecimal stockActualLote = lote.getCantidadActual();
+        BigDecimal stockActualProducto = producto.getStockActual();
+
+        switch (tipoAjuste) {
+            case Entrada -> {
+                lote.setCantidadActual(stockActualLote.add(cantidad));
+                producto.setStockActual(stockActualProducto.add(cantidad));
+            }
+            case Salida -> {
+                if (stockActualLote.compareTo(cantidad) < 0 || stockActualProducto.compareTo(cantidad) < 0) {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                            "No hay existencias suficientes para registrar el ajuste de salida");
+                }
+                lote.setCantidadActual(stockActualLote.subtract(cantidad));
+                producto.setStockActual(stockActualProducto.subtract(cantidad));
+            }
+        }
+    }
+
+    private void revertirImpactoInventario(AjusteInventario ajuste) {
+        Lote lote = obtenerLoteGestionado(ajuste.getLote());
+        Producto producto = lote.getProducto();
+        BigDecimal cantidad = ajuste.getCantidad();
+
+        ajuste.setLote(lote);
+
+        if (ajuste.getTipoAjuste() == TipoAjuste.Entrada) {
+            if (lote.getCantidadActual().compareTo(cantidad) < 0 || producto.getStockActual().compareTo(cantidad) < 0) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "No es posible revertir el ajuste porque dejaría existencias negativas");
+            }
+            lote.setCantidadActual(lote.getCantidadActual().subtract(cantidad));
+            producto.setStockActual(producto.getStockActual().subtract(cantidad));
+        } else {
+            lote.setCantidadActual(lote.getCantidadActual().add(cantidad));
+            producto.setStockActual(producto.getStockActual().add(cantidad));
+        }
+
+        productoService.guardar(producto);
+        loteService.guardar(lote);
     }
 }

--- a/src/main/java/com/inventa/inventa/service/ContactoProveedorService.java
+++ b/src/main/java/com/inventa/inventa/service/ContactoProveedorService.java
@@ -1,0 +1,39 @@
+package com.inventa.inventa.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.inventa.inventa.entity.ContactoProveedor;
+import com.inventa.inventa.repository.ContactoProveedorRepository;
+
+@Service
+public class ContactoProveedorService {
+
+    private final ContactoProveedorRepository contactoProveedorRepository;
+
+    public ContactoProveedorService(ContactoProveedorRepository contactoProveedorRepository) {
+        this.contactoProveedorRepository = contactoProveedorRepository;
+    }
+
+    public List<ContactoProveedor> listar() {
+        return contactoProveedorRepository.findAll();
+    }
+
+    public Optional<ContactoProveedor> buscarPorId(Integer id) {
+        return contactoProveedorRepository.findById(id);
+    }
+
+    public List<ContactoProveedor> listarPorProveedor(Integer proveedorId) {
+        return contactoProveedorRepository.findByProveedorProveedorId(proveedorId);
+    }
+
+    public ContactoProveedor guardar(ContactoProveedor contactoProveedor) {
+        return contactoProveedorRepository.save(contactoProveedor);
+    }
+
+    public void eliminar(Integer id) {
+        contactoProveedorRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/inventa/inventa/service/LoteService.java
+++ b/src/main/java/com/inventa/inventa/service/LoteService.java
@@ -1,0 +1,31 @@
+package com.inventa.inventa.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.inventa.inventa.entity.Lote;
+import com.inventa.inventa.repository.LoteRepository;
+
+@Service
+public class LoteService {
+
+    private final LoteRepository loteRepository;
+
+    public LoteService(LoteRepository loteRepository) {
+        this.loteRepository = loteRepository;
+    }
+
+    public List<Lote> listar() {
+        return loteRepository.findAll();
+    }
+
+    public Optional<Lote> buscarPorId(Integer id) {
+        return loteRepository.findById(id);
+    }
+
+    public Lote guardar(Lote lote) {
+        return loteRepository.save(lote);
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+spring.datasource.url=jdbc:h2:mem:inventagt;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.default_schema=PUBLIC
+spring.jpa.show-sql=false


### PR DESCRIPTION
## Summary
- add mapper, service logic, and REST controller to manage ajustes de inventario while syncing lote and producto stock
- expose CRUD endpoints and mapper/service support for contactos de proveedor
- configure an in-memory H2 datasource for tests and enable it via a new application.properties under src/test/resources

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68dc8fa6c74c832887e6a60a7725d3d7